### PR TITLE
Dual trees

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,8 +48,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let file_contents = fs::read_to_string(file)?;
 
-            let generated_sha256_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha256);
+            let generated_sha1_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha1);
+            println!("Generated {:?} GitOid: {}", generated_sha1_gitoid.hash_algorithm(), generated_sha1_gitoid.hash());
+//            let gitoid_directories = create_gitoid_directory(&generated_sha1_gitoid)?;
+//            write_gitoid_file(&generated_sha1_gitoid, gitoid_directories)?;
+ //           write_gitbom_file(&generated_sha1_gitoid)?;
 
+            let generated_sha256_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha256);
             println!("Generated {:?} GitOid: {}", generated_sha256_gitoid.hash_algorithm(), generated_sha256_gitoid.hash());
             let gitoid_directories = create_gitoid_directory(&generated_sha256_gitoid)?;
             write_gitoid_file(&generated_sha256_gitoid, gitoid_directories)?;
@@ -78,7 +83,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     let file_contents = fs::read_to_string(entry_clone.path())?;
 
                     let generated_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha256);
-                    println!("Generated GitOid: {}", generated_gitoid.hash());
+                    println!("Generated {:?} GitOid: {}", generated_gitoid.hash_algorithm(), generated_gitoid.hash());
                     let gitoid_directories = create_gitoid_directory(&generated_gitoid)?;
                     write_gitoid_file(&generated_gitoid, gitoid_directories)?;
                     gitbom.add(generated_gitoid);

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Bom { file } => {
             println!("Generating GitBOM for {}", file);
             create_gitbom_directory()?;
+            create_gitbom_file(HashAlgorithm::Sha1)?;
             create_gitbom_file(HashAlgorithm::Sha256)?;
 
             let file_contents = fs::read_to_string(file)?;
@@ -52,7 +53,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("Generated {:?} GitOid: {}", generated_sha1_gitoid.hash_algorithm(), generated_sha1_gitoid.hash());
             let gitoid_directories = create_gitoid_directory(&generated_sha1_gitoid)?;
             write_gitoid_file(&generated_sha1_gitoid, gitoid_directories)?;
- //           write_gitbom_file(&generated_sha1_gitoid)?;
+            write_gitbom_file(&generated_sha1_gitoid, generated_sha1_gitoid.hash_algorithm())?;
 
             let generated_sha256_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha256);
             println!("Generated {:?} GitOid: {}", generated_sha256_gitoid.hash_algorithm(), generated_sha256_gitoid.hash());
@@ -60,6 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             write_gitoid_file(&generated_sha256_gitoid, gitoid_directories)?;
             write_gitbom_file(&generated_sha256_gitoid, HashAlgorithm::Sha256)?;
 
+            hash_gitbom_file(HashAlgorithm::Sha1)?;
             hash_gitbom_file(HashAlgorithm::Sha256)?;
 
             Ok(())
@@ -170,7 +172,7 @@ fn write_gitbom_file(gitoid: &GitOid, hash_algorithm: HashAlgorithm) -> std::io:
 fn hash_gitbom_file(hash_algorithm: HashAlgorithm) -> Result<(), gitoid::Error> {
     let gitbom_file_path = format!("{}/gitbom_{}_temp", GITBOM_DIRECTORY, hash_algorithm);
     let file_contents = fs::read_to_string(gitbom_file_path.clone())?;
-    let generated_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha256);
+    let generated_gitoid = create_gitoid_for_file(&file_contents, hash_algorithm);
 
     println!("GitOid for {:?} GitBOM file: {}", generated_gitoid.hash_algorithm(), generated_gitoid.hash());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::ArtifactTree { directory } => {
             println!("Generating GitBOM for {}", directory);
             create_gitbom_directory()?;
+            create_gitbom_file(HashAlgorithm::Sha1)?;
             create_gitbom_file(HashAlgorithm::Sha256)?;
             
             let mut count = 0;
@@ -76,6 +77,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     let file_contents = fs::read_to_string(entry_clone.path())?;
 
+//                    let generated_sha1_gitoid = generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha1)?;
                     let generated_gitoid = generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha256)?;
                     gitbom.add(generated_gitoid);
                     count += 1;
@@ -87,6 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                write_gitbom_file(&gitoid, HashAlgorithm::Sha256)?;
            } 
 
+            hash_gitbom_file(HashAlgorithm::Sha1)?;
             hash_gitbom_file(HashAlgorithm::Sha256)?;
             println!("Generated GitBom for {} files", count);
             Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use gitbom::GitBom;
 use gitoid::{HashAlgorithm, GitOid, ObjectType::Blob};
 use clap::{Parser, Subcommand};
 use std::collections::HashMap;
@@ -66,8 +65,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             
             let mut count = 0;
 
-            let gitbom = GitBom::new();
-
             // Generate GitOids for every file within directory
             for entry in WalkDir::new(directory) {
                 let entry_clone = entry?.clone();
@@ -77,17 +74,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     let file_contents = fs::read_to_string(entry_clone.path())?;
 
-//                    let generated_sha1_gitoid = generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha1)?;
-                    let generated_gitoid = generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha256)?;
-                    gitbom.add(generated_gitoid);
+                    generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha1)?;
+                    generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha256)?;
                     count += 1;
                 }
                 
             }
-
-           for gitoid in gitbom.get_oids() {
-               write_gitbom_file(&gitoid, HashAlgorithm::Sha256)?;
-           } 
 
             hash_gitbom_file(HashAlgorithm::Sha1)?;
             hash_gitbom_file(HashAlgorithm::Sha256)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha1)?;
             generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha256)?;
 
+
             hash_gitbom_file(HashAlgorithm::Sha1)?;
             hash_gitbom_file(HashAlgorithm::Sha256)?;
 
@@ -79,6 +80,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("Generated {:?} GitOid: {}", generated_gitoid.hash_algorithm(), generated_gitoid.hash());
                     let gitoid_directories = create_gitoid_directory(&generated_gitoid)?;
                     write_gitoid_file(&generated_gitoid, gitoid_directories)?;
+//                    generate_and_write_gitoid(file_contents, HashAlgorithm::Sha256);
                     gitbom.add(generated_gitoid);
                     count += 1;
                 }
@@ -177,7 +179,7 @@ fn hash_gitbom_file(hash_algorithm: HashAlgorithm) -> Result<(), gitoid::Error> 
     Ok(())
 }
 
-fn generate_and_write_gitoid(file_contents: &str, hash_algorithm: HashAlgorithm) -> std::io::Result<()> {
+fn generate_and_write_gitoid(file_contents: &str, hash_algorithm: HashAlgorithm) -> std::io::Result<GitOid> {
     let generated_gitoid = create_gitoid_for_file(&file_contents, hash_algorithm);
     println!("Generated {:?} GitOid: {}", generated_gitoid.hash_algorithm(), generated_gitoid.hash());
     let gitoid_directories = create_gitoid_directory(&generated_gitoid)?;
@@ -185,5 +187,5 @@ fn generate_and_write_gitoid(file_contents: &str, hash_algorithm: HashAlgorithm)
     write_gitoid_file(&generated_gitoid, gitoid_directories)?;
     write_gitbom_file(&generated_gitoid, generated_gitoid.hash_algorithm())?;
 
-    Ok(())
+    Ok(generated_gitoid)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,11 +58,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let sha256_gitoid = generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha256)?;
             let sha256_gitbom = sha256_gitbom.add(sha256_gitoid);
 
-            for gitoid in sha1_gitbom.get_oids() {
+            for gitoid in sha1_gitbom.get_sorted_oids() {
                 write_gitbom_file(&gitoid, HashAlgorithm::Sha1)?
             }
 
-            for gitoid in sha256_gitbom.get_oids() {
+            for gitoid in sha256_gitbom.get_sorted_oids() {
                 write_gitbom_file(&gitoid, HashAlgorithm::Sha256)?
             }
 
@@ -101,11 +101,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
 
-            for gitoid in sha1_gitbom.get_oids() {
+            for gitoid in sha1_gitbom.get_sorted_oids() {
                 write_gitbom_file(&gitoid, HashAlgorithm::Sha1)?
             }
 
-            for gitoid in sha256_gitbom.get_oids() {
+            for gitoid in sha256_gitbom.get_sorted_oids() {
                 write_gitbom_file(&gitoid, HashAlgorithm::Sha256)?
             }
 
@@ -185,6 +185,7 @@ fn write_gitbom_file(gitoid: &GitOid, hash_algorithm: HashAlgorithm) -> std::io:
 fn hash_gitbom_file(hash_algorithm: HashAlgorithm) -> Result<(), gitoid::Error> {
     let gitbom_file_path = format!("{}/gitbom_{}_temp", GITBOM_DIRECTORY, hash_algorithm);
     let file_contents = fs::read_to_string(gitbom_file_path.clone())?;
+    print!("file_contents for {} gitbom file: {:?}", hash_algorithm, file_contents);
 
     let generated_gitoid = create_gitoid_for_file(&file_contents, hash_algorithm);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,12 +76,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     let file_contents = fs::read_to_string(entry_clone.path())?;
 
-/*                     let generated_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha256);
-                    println!("Generated {:?} GitOid: {}", generated_gitoid.hash_algorithm(), generated_gitoid.hash());
-                    let gitoid_directories = create_gitoid_directory(&generated_gitoid)?;
-                    write_gitoid_file(&generated_gitoid, gitoid_directories)?;
-
- */                 let generated_gitoid = generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha256)?;
+                    let generated_gitoid = generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha256)?;
                     gitbom.add(generated_gitoid);
                     count += 1;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,7 +121,8 @@ fn create_gitbom_directory() -> std::io::Result<()> {
 fn create_gitbom_file(hash_algorithm: HashAlgorithm) -> std::io::Result<()> {
     let file_path = format!("{}/gitbom_{}_temp", GITBOM_DIRECTORY, hash_algorithm);
     let mut gitbom_file = File::create(file_path)?;
-    gitbom_file.write_all("gitoid:blob:sha1\n".to_string().as_bytes())?;
+    let header_text = format!("gitoid:blob:{}\n", hash_algorithm).to_lowercase();
+    gitbom_file.write_all(header_text.as_bytes())?;
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,11 +76,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     let file_contents = fs::read_to_string(entry_clone.path())?;
 
-                    let generated_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha256);
+/*                     let generated_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha256);
                     println!("Generated {:?} GitOid: {}", generated_gitoid.hash_algorithm(), generated_gitoid.hash());
                     let gitoid_directories = create_gitoid_directory(&generated_gitoid)?;
                     write_gitoid_file(&generated_gitoid, gitoid_directories)?;
-//                    generate_and_write_gitoid(file_contents, HashAlgorithm::Sha256);
+
+ */                 let generated_gitoid = generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha256)?;
                     gitbom.add(generated_gitoid);
                     count += 1;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             match generated_gitoid {
                 Ok(gitoid) => {
-                    println!("Generated GitOid: {}", gitoid.hash());
+                    println!("Generated {:?} GitOid: {}", gitoid.hash_algorithm(), gitoid.hash());
                     let gitoid_directories = create_gitoid_directory(&gitoid)?;
                     write_gitoid_file(&gitoid, gitoid_directories)?;
                     write_gitbom_file(&gitoid)?;
@@ -180,7 +180,7 @@ fn hash_gitbom_file() -> Result<(), gitoid::Error> {
         Err(e) => return Err(e)
     };
 
-    println!("GitOid for GitBOM file: {}", gitoid.hash());
+    println!("GitOid for {:?} GitBOM file: {}", gitoid.hash_algorithm(), gitoid.hash());
 
     let gitoid_directories = create_gitoid_directory(&gitoid)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,17 +49,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             let file_contents = fs::read_to_string(file)?;
 
-            let generated_sha1_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha1);
-            println!("Generated {:?} GitOid: {}", generated_sha1_gitoid.hash_algorithm(), generated_sha1_gitoid.hash());
-            let gitoid_directories = create_gitoid_directory(&generated_sha1_gitoid)?;
-            write_gitoid_file(&generated_sha1_gitoid, gitoid_directories)?;
-            write_gitbom_file(&generated_sha1_gitoid, generated_sha1_gitoid.hash_algorithm())?;
-
-            let generated_sha256_gitoid = create_gitoid_for_file(&file_contents, HashAlgorithm::Sha256);
-            println!("Generated {:?} GitOid: {}", generated_sha256_gitoid.hash_algorithm(), generated_sha256_gitoid.hash());
-            let gitoid_directories = create_gitoid_directory(&generated_sha256_gitoid)?;
-            write_gitoid_file(&generated_sha256_gitoid, gitoid_directories)?;
-            write_gitbom_file(&generated_sha256_gitoid, HashAlgorithm::Sha256)?;
+            generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha1)?;
+            generate_and_write_gitoid(&file_contents, HashAlgorithm::Sha256)?;
 
             hash_gitbom_file(HashAlgorithm::Sha1)?;
             hash_gitbom_file(HashAlgorithm::Sha256)?;
@@ -183,5 +174,16 @@ fn hash_gitbom_file(hash_algorithm: HashAlgorithm) -> Result<(), gitoid::Error> 
     fs::copy(&gitbom_file_path, new_file_path)?;
 
     fs::remove_file(gitbom_file_path)?;
+    Ok(())
+}
+
+fn generate_and_write_gitoid(file_contents: &str, hash_algorithm: HashAlgorithm) -> std::io::Result<()> {
+    let generated_gitoid = create_gitoid_for_file(&file_contents, hash_algorithm);
+    println!("Generated {:?} GitOid: {}", generated_gitoid.hash_algorithm(), generated_gitoid.hash());
+    let gitoid_directories = create_gitoid_directory(&generated_gitoid)?;
+
+    write_gitoid_file(&generated_gitoid, gitoid_directories)?;
+    write_gitbom_file(&generated_gitoid, generated_gitoid.hash_algorithm())?;
+
     Ok(())
 }

--- a/tests/bom.rs
+++ b/tests/bom.rs
@@ -103,7 +103,7 @@ fn generating_sha1_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
     cmd.current_dir("temp_test_dir_5");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("Generated SHA1 GitOid"));
+        .stdout(predicate::str::contains("Generated Sha1 GitOid"));
 
     fs::remove_dir_all("temp_test_dir_5")?;
     Ok(())

--- a/tests/bom.rs
+++ b/tests/bom.rs
@@ -103,7 +103,10 @@ fn generating_sha1_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
     cmd.current_dir("temp_test_dir_5");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("Generated Sha1 GitOid"));
+        .stdout(predicate::str::contains("Generated Sha1 GitOid: 70c379b63ffa0795fdbfbc128e5a2818397b7ef8"));
+
+    let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/70/c379b63ffa0795fdbfbc128e5a2818397b7ef8").exists();
+    assert_eq!(gitoid_dir_exists, true);
 
     fs::remove_dir_all("temp_test_dir_5")?;
     Ok(())
@@ -130,18 +133,3 @@ fn generating_sha256_bom_gitoid_file() -> Result<(), Box<dyn std::error::Error>>
     fs::remove_dir_all("temp_test_dir_6")?;
     Ok(())
 }
-
-/* #[test]
-fn generating_sha256_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
-    fs::create_dir_all("temp_test_dir_6")?;
-
-    let mut cmd = Command::cargo_bin("gitbom-cli")?;
-    cmd.arg("bom").arg("../tests/fixtures/hello.txt");
-    cmd.current_dir("temp_test_dir_6");
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: bb926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc"));
-
-    fs::remove_dir_all("temp_test_dir_6")?;
-    Ok(())
-} */

--- a/tests/bom.rs
+++ b/tests/bom.rs
@@ -121,14 +121,15 @@ fn generating_sha256_bom_gitoid_file() -> Result<(), Box<dyn std::error::Error>>
     cmd.current_dir("temp_test_dir_6");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: bb926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc"));
+        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: 2ae40c6af39af6d75cca304157d2483e8e85526eaad7b7d2a2a386343d5efad7"));
 
-    let gitoid_dir_exists = Path::new("temp_test_dir_6/.bom/objects/bb/926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc").exists();
+    let gitoid_dir_exists = Path::new("temp_test_dir_6/.bom/objects/2a/e40c6af39af6d75cca304157d2483e8e85526eaad7b7d2a2a386343d5efad7").exists();
     assert_eq!(gitoid_dir_exists, true);
 
-    let file_contents = fs::read_to_string("temp_test_dir_6/.bom/objects/bb/926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc")?;
+
+    let file_contents = fs::read_to_string("temp_test_dir_6/.bom/objects/2a/e40c6af39af6d75cca304157d2483e8e85526eaad7b7d2a2a386343d5efad7")?;
     println!("{}", file_contents);
-    assert!(file_contents.contains("gitoid:blob:sha1\n"));
+    assert!(file_contents.contains("gitoid:blob:sha256\n"));
 
     fs::remove_dir_all("temp_test_dir_6")?;
     Ok(())

--- a/tests/bom.rs
+++ b/tests/bom.rs
@@ -133,3 +133,26 @@ fn generating_sha256_bom_gitoid_file() -> Result<(), Box<dyn std::error::Error>>
     fs::remove_dir_all("temp_test_dir_6")?;
     Ok(())
 }
+
+#[test]
+fn generating_sha1_bom_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
+    fs::create_dir_all("temp_test_dir_7")?;
+
+    let mut cmd = Command::cargo_bin("gitbom-cli")?;
+    cmd.arg("bom").arg("../tests/fixtures/hello.txt");
+    cmd.current_dir("temp_test_dir_7");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("GitOid for Sha1 GitBOM file: 8b8e6bf1664bb88b8f979816fe2b73585a62580d"));
+
+    let gitoid_dir_exists = Path::new("temp_test_dir_7/.bom/objects/8b/8e6bf1664bb88b8f979816fe2b73585a62580d").exists();
+    assert_eq!(gitoid_dir_exists, true);
+ 
+     
+    let file_contents = fs::read_to_string("temp_test_dir_7/.bom/objects/8b/8e6bf1664bb88b8f979816fe2b73585a62580d")?;
+    println!("{}", file_contents);
+    assert!(file_contents.contains("gitoid:blob:sha1\n"));
+
+    fs::remove_dir_all("temp_test_dir_7")?;
+    Ok(())
+}

--- a/tests/bom.rs
+++ b/tests/bom.rs
@@ -78,7 +78,7 @@ fn when_bom_directory_already_exists() -> Result<(), Box<dyn std::error::Error>>
 }
 
 #[test]
-fn generating_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
+fn generating_sha256_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
     fs::create_dir_all("temp_test_dir_4")?;
 
     let mut cmd = Command::cargo_bin("gitbom-cli")?;
@@ -86,7 +86,7 @@ fn generating_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
     cmd.current_dir("temp_test_dir_4");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("Generated GitOid: 5b2f2d4e79e6387ca9dedad500ebf70e9fb3097773252cc5b9a6d5a35a987028"));
+        .stdout(predicate::str::contains("Generated Sha256 GitOid: 5b2f2d4e79e6387ca9dedad500ebf70e9fb3097773252cc5b9a6d5a35a987028"));
 
     let gitoid_dir_exists = Path::new("temp_test_dir_4/.bom/objects/5b/2f2d4e79e6387ca9dedad500ebf70e9fb3097773252cc5b9a6d5a35a987028").exists();
     assert_eq!(gitoid_dir_exists, true);
@@ -103,15 +103,45 @@ fn generating_sha1_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
     cmd.current_dir("temp_test_dir_5");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GitOid for GitBOM file: bb926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc"));
-
-    let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/bb/926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc").exists();
-    assert_eq!(gitoid_dir_exists, true);
-
-    let file_contents = fs::read_to_string("temp_test_dir_5/.bom/objects/bb/926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc")?;
-    println!("{}", file_contents);
-    assert!(file_contents.contains("gitoid:blob:sha1\n"));
+        .stdout(predicate::str::contains("Generated SHA1 GitOid"));
 
     fs::remove_dir_all("temp_test_dir_5")?;
     Ok(())
 }
+
+#[test]
+fn generating_sha256_bom_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
+    fs::create_dir_all("temp_test_dir_6")?;
+
+    let mut cmd = Command::cargo_bin("gitbom-cli")?;
+    cmd.arg("bom").arg("../tests/fixtures/hello.txt");
+    cmd.current_dir("temp_test_dir_6");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: bb926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc"));
+
+    let gitoid_dir_exists = Path::new("temp_test_dir_6/.bom/objects/bb/926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc").exists();
+    assert_eq!(gitoid_dir_exists, true);
+
+    let file_contents = fs::read_to_string("temp_test_dir_6/.bom/objects/bb/926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc")?;
+    println!("{}", file_contents);
+    assert!(file_contents.contains("gitoid:blob:sha1\n"));
+
+    fs::remove_dir_all("temp_test_dir_6")?;
+    Ok(())
+}
+
+/* #[test]
+fn generating_sha256_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
+    fs::create_dir_all("temp_test_dir_6")?;
+
+    let mut cmd = Command::cargo_bin("gitbom-cli")?;
+    cmd.arg("bom").arg("../tests/fixtures/hello.txt");
+    cmd.current_dir("temp_test_dir_6");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: bb926c2989b072fa387968f6a68b6f448e495555205aa9b10f179cf7860730bc"));
+
+    fs::remove_dir_all("temp_test_dir_6")?;
+    Ok(())
+} */

--- a/tests/bom.rs
+++ b/tests/bom.rs
@@ -151,7 +151,6 @@ fn generating_sha1_bom_gitoid_file() -> Result<(), Box<dyn std::error::Error>> {
  
      
     let file_contents = fs::read_to_string("temp_test_dir_7/.bom/objects/8b/8e6bf1664bb88b8f979816fe2b73585a62580d")?;
-    println!("{}", file_contents);
     assert!(file_contents.contains("gitoid:blob:sha1\n"));
 
     fs::remove_dir_all("temp_test_dir_7")?;

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![feature(option_result_contains)]
 
 use assert_cmd::Command;
 use std::path::Path;

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -93,9 +93,9 @@ fn generating_gitoid_for_sha256_bom_file() -> Result<(), Box<dyn std::error::Err
     cmd.current_dir("temp_test_dir_5");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: 5780f55500bd30463e4d9616559421fc512bd8debcdec4a23662763753f82895"));
+        .stdout(predicate::str::contains("e0b484d7b3c45c804eae87f2c15edb64123419729b341d6289f23cea89d23e04"));
 
-    let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/57/80f55500bd30463e4d9616559421fc512bd8debcdec4a23662763753f82895").exists();
+    let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/e0/b484d7b3c45c804eae87f2c15edb64123419729b341d6289f23cea89d23e04").exists();
     assert_eq!(gitoid_dir_exists, true);
 
     fs::remove_dir_all("temp_test_dir_5")?;

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -71,7 +71,19 @@ fn generating_gitoid_files() -> Result<(), Box<dyn std::error::Error>> {
 
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("Generated Sha256 GitOid: 99288e47fc18ca8301c2ab1fc67c6d176e344d4528c618705967f8191254bb17\nGenerated Sha256 GitOid: 88737472dddbec36c85dc76803dd92c045a5d5c2a1d96c024d16e2fe92f5a734"));
+        .stdout(predicate::str::contains("Generated Sha256 GitOid: 99288e47fc18ca8301c2ab1fc67c6d176e344d4528c618705967f8191254bb17\n"));
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Generated Sha256 GitOid: 88737472dddbec36c85dc76803dd92c045a5d5c2a1d96c024d16e2fe92f5a734"));
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Generated Sha1 GitOid: 3bbaf1bfd298af102de0a2a1065f8ec674daae4c"));
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Generated Sha1 GitOid: 7fcdb5a991587f05f251d23f84d0fb3b027d464e"));
 
     cmd.assert()
         .success()
@@ -81,6 +93,10 @@ fn generating_gitoid_files() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(first_gitoid_dir_exists, true);
     let second_gitoid_dir_exists = Path::new("temp_test_dir_4/.bom/objects/88/737472dddbec36c85dc76803dd92c045a5d5c2a1d96c024d16e2fe92f5a734").exists();
     assert_eq!(second_gitoid_dir_exists, true);
+    let third_gitoid_dir_exists = Path::new("temp_test_dir_4/.bom/objects/3b/baf1bfd298af102de0a2a1065f8ec674daae4c").exists();
+    assert_eq!(third_gitoid_dir_exists, true);
+    let fourth_gitoid_dir_exists = Path::new("temp_test_dir_4/.bom/objects/7f/cdb5a991587f05f251d23f84d0fb3b027d464e").exists();
+    assert_eq!(fourth_gitoid_dir_exists, true);
     fs::remove_dir_all("temp_test_dir_4")?;
     Ok(())
 }
@@ -112,9 +128,9 @@ fn generating_gitoid_for_sha1_bom_file() -> Result<(), Box<dyn std::error::Error
     cmd.current_dir("temp_test_dir_6");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GitOid for Sha1 GitBOM file: daa8845467f5d281d4d233a69af67b85dd50f9f0"));
+        .stdout(predicate::str::contains("GitOid for Sha1 GitBOM file: 97cb5351c67a9f183caa2a19071814e1431984f5"));
 
-    let gitoid_dir_exists = Path::new("temp_test_dir_6/.bom/objects/da/a8845467f5d281d4d233a69af67b85dd50f9f0").exists();
+    let gitoid_dir_exists = Path::new("temp_test_dir_6/.bom/objects/97/cb5351c67a9f183caa2a19071814e1431984f5").exists();
     assert_eq!(gitoid_dir_exists, true);
 
     fs::remove_dir_all("temp_test_dir_6")?;

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -93,9 +93,9 @@ fn generating_gitoid_for_sha256_bom_file() -> Result<(), Box<dyn std::error::Err
     cmd.current_dir("temp_test_dir_5");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: 056c617ab64860f6933e49cdf3abb35f742f17df7146648eb3b793612178ee87"));
+        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: 5780f55500bd30463e4d9616559421fc512bd8debcdec4a23662763753f82895"));
 
-    let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/05/6c617ab64860f6933e49cdf3abb35f742f17df7146648eb3b793612178ee87").exists();
+    let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/57/80f55500bd30463e4d9616559421fc512bd8debcdec4a23662763753f82895").exists();
     assert_eq!(gitoid_dir_exists, true);
 
     fs::remove_dir_all("temp_test_dir_5")?;

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -68,6 +68,7 @@ fn generating_gitoid_files() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("gitbom-cli")?;
     cmd.arg("artifact-tree").arg("../tests/fixtures/directory_thing");
     cmd.current_dir("temp_test_dir_4");
+
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("Generated Sha256 GitOid: 99288e47fc18ca8301c2ab1fc67c6d176e344d4528c618705967f8191254bb17\nGenerated Sha256 GitOid: 88737472dddbec36c85dc76803dd92c045a5d5c2a1d96c024d16e2fe92f5a734"));
@@ -93,11 +94,29 @@ fn generating_gitoid_for_sha256_bom_file() -> Result<(), Box<dyn std::error::Err
     cmd.current_dir("temp_test_dir_5");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("e0b484d7b3c45c804eae87f2c15edb64123419729b341d6289f23cea89d23e04"));
+        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: e0b484d7b3c45c804eae87f2c15edb64123419729b341d6289f23cea89d23e04"));
 
     let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/e0/b484d7b3c45c804eae87f2c15edb64123419729b341d6289f23cea89d23e04").exists();
     assert_eq!(gitoid_dir_exists, true);
 
     fs::remove_dir_all("temp_test_dir_5")?;
+    Ok(())
+}
+
+#[test]
+fn generating_gitoid_for_sha1_bom_file() -> Result<(), Box<dyn std::error::Error>> {
+    fs::create_dir_all("temp_test_dir_6")?;
+
+    let mut cmd = Command::cargo_bin("gitbom-cli")?;
+    cmd.arg("artifact-tree").arg("../tests/fixtures/directory_thing");
+    cmd.current_dir("temp_test_dir_6");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("GitOid for Sha1 GitBOM file: daa8845467f5d281d4d233a69af67b85dd50f9f0"));
+
+    let gitoid_dir_exists = Path::new("temp_test_dir_6/.bom/objects/da/a8845467f5d281d4d233a69af67b85dd50f9f0").exists();
+    assert_eq!(gitoid_dir_exists, true);
+
+    fs::remove_dir_all("temp_test_dir_6")?;
     Ok(())
 }

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -111,9 +111,9 @@ fn generating_gitoid_for_sha256_bom_file() -> Result<(), Box<dyn std::error::Err
     cmd.current_dir("temp_test_dir_5");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: e0b484d7b3c45c804eae87f2c15edb64123419729b341d6289f23cea89d23e04"));
+        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: 9e96d2713315518b59d95efefbe4767f91c1314437f8eab1c15c1017d710e917"));
 
-    let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/e0/b484d7b3c45c804eae87f2c15edb64123419729b341d6289f23cea89d23e04").exists();
+    let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/9e/96d2713315518b59d95efefbe4767f91c1314437f8eab1c15c1017d710e917").exists();
     assert_eq!(gitoid_dir_exists, true);
 
     fs::remove_dir_all("temp_test_dir_5")?;

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -70,7 +70,7 @@ fn generating_gitoid_files() -> Result<(), Box<dyn std::error::Error>> {
     cmd.current_dir("temp_test_dir_4");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("Generated GitOid: 99288e47fc18ca8301c2ab1fc67c6d176e344d4528c618705967f8191254bb17\nGenerated GitOid: 88737472dddbec36c85dc76803dd92c045a5d5c2a1d96c024d16e2fe92f5a734"));
+        .stdout(predicate::str::contains("Generated Sha256 GitOid: 99288e47fc18ca8301c2ab1fc67c6d176e344d4528c618705967f8191254bb17\nGenerated Sha256 GitOid: 88737472dddbec36c85dc76803dd92c045a5d5c2a1d96c024d16e2fe92f5a734"));
 
     cmd.assert()
         .success()
@@ -93,7 +93,7 @@ fn generating_gitoid_for_sha256_bom_file() -> Result<(), Box<dyn std::error::Err
     cmd.current_dir("temp_test_dir_5");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GitOid for SHA256 GitBOM file: 056c617ab64860f6933e49cdf3abb35f742f17df7146648eb3b793612178ee87"));
+        .stdout(predicate::str::contains("GitOid for Sha256 GitBOM file: 056c617ab64860f6933e49cdf3abb35f742f17df7146648eb3b793612178ee87"));
 
     let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/05/6c617ab64860f6933e49cdf3abb35f742f17df7146648eb3b793612178ee87").exists();
     assert_eq!(gitoid_dir_exists, true);

--- a/tests/tree.rs
+++ b/tests/tree.rs
@@ -85,7 +85,7 @@ fn generating_gitoid_files() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn generating_gitoid_for_sha1_bom_file() -> Result<(), Box<dyn std::error::Error>> {
+fn generating_gitoid_for_sha256_bom_file() -> Result<(), Box<dyn std::error::Error>> {
     fs::create_dir_all("temp_test_dir_5")?;
 
     let mut cmd = Command::cargo_bin("gitbom-cli")?;
@@ -93,7 +93,7 @@ fn generating_gitoid_for_sha1_bom_file() -> Result<(), Box<dyn std::error::Error
     cmd.current_dir("temp_test_dir_5");
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("GitOid for GitBOM file: 056c617ab64860f6933e49cdf3abb35f742f17df7146648eb3b793612178ee87"));
+        .stdout(predicate::str::contains("GitOid for SHA256 GitBOM file: 056c617ab64860f6933e49cdf3abb35f742f17df7146648eb3b793612178ee87"));
 
     let gitoid_dir_exists = Path::new("temp_test_dir_5/.bom/objects/05/6c617ab64860f6933e49cdf3abb35f742f17df7146648eb3b793612178ee87").exists();
     assert_eq!(gitoid_dir_exists, true);


### PR DESCRIPTION
Implements dual trees as specified in the [GitBOM Spec](https://github.com/git-bom/spec/blob/main/SPEC.md#artifact-identifier-types).

Benchmarks are currently failing due to https://github.com/rust-lang/rust/issues/103794 (hopefully will be resolved with the next nightly build)